### PR TITLE
Fix MODE option in swarm mode documentation

### DIFF
--- a/articles/swarm-mode.md
+++ b/articles/swarm-mode.md
@@ -86,7 +86,7 @@ docker service create --name proxy \
     -p 443:443 \
     -p 8080:8080 \
     --network proxy \
-    -e MODE=service \
+    -e MODE=swarm \
     --constraint node.id==$(docker node inspect node-1 --format "{{.ID}}") \
     vfarcic/docker-flow-proxy
 ```


### PR DESCRIPTION
Text says that proxy mode should be set to `swarm`, but code example shows `service`