### PR TITLE
Update haproxy template container path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The base HAProxy configuration can be found in [haproxy.tmpl](haproxy.tmpl). It 
 
 ```
 FROM vfarcic/docker-flow-proxy
-COPY haproxy.tmpl /cfg/haproxy.tmpl
+COPY haproxy.tmpl /cfg/tmpl/haproxy.tmpl
 ```
 
 ### Reconfigure

--- a/articles/swarm-mode-listener.md
+++ b/articles/swarm-mode-listener.md
@@ -318,7 +318,7 @@ There are two ways we can add certificates to the proxy. One is to create your o
 ```
 FROM vfarcic/docker-flow-proxy
 COPY my-cert.pem /certs/my-cert.pem
-COPY haproxy.tmpl /cfg/haproxy.tmpl
+COPY haproxy.tmpl /cfg/tmpl/haproxy.tmpl
 ```
 
 When the image is built, it will be based on `vfarcic/docker-flow-proxy` and include `my-cert.pem` and `haproxy.tmpl` files. The `my-cert.pem` would be your certificate and the `haproxy.tmpl` the modified version of the original proxy template located in [https://github.com/vfarcic/docker-flow-proxy/blob/master/haproxy.tmpl](https://github.com/vfarcic/docker-flow-proxy/blob/master/haproxy.tmpl). You'd need to replace `{{.CertsString}}` with ` ssl crt /certs/my-cert.pem` (please note that the string should start with space). The complete line would be as follows.


### PR DESCRIPTION
Hi there!

I noticed in the README and "Swarm Mode with Automatic Configuration" docs that `/cfg/haproxy.tmpl`  is used when describing how to create a custom haproxy config / image, but it should actually be `/cfg/tmpl/haproxy.tmpl`.

I ran a quick recursive search over all the files (`grep -rnw . -e "/cfg/haproxy.tmpl"`) and these were the only two occurrences I found.

Thank you so much for your time!