### PR TITLE
Hardening ssl ciphers and disable sslv3

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -2,6 +2,13 @@ global
     pidfile /var/run/haproxy.pid
     tune.ssl.default-dh-param 2048{{.ExtraGlobal}}
 
+    #disable sslv3, prefer modern ciphers
+    ssl-default-bind-options no-sslv3
+    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
+    ssl-default-server-options no-sslv3
+    ssl-default-server-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+
 defaults
     mode    http
     balance roundrobin


### PR DESCRIPTION
This PR disables sslv3 globally for all HAproxy backends and prefers modern ssl ciphers.

Qualys SSL Server Test rating improved from C to A.

When this PR is merged, SSL Handshake with the following Clients will fail:
```
IE6 & IE8 on Windows XP 
Java 6u45
```