### PR TITLE
fancy error pages using materialized bootstrap

### DIFF
--- a/errorfiles/400.http
+++ b/errorfiles/400.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>400 Bad Request</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 400 Bad Request</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/403.http
+++ b/errorfiles/403.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>403 Forbidden</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 403 Forbidden</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/405.http
+++ b/errorfiles/405.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>405 Method Not Allowed</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 405 Method Not Allowed</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/408.http
+++ b/errorfiles/408.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>408 Request Timeout</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 408 Request Timeout</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/429.http
+++ b/errorfiles/429.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>429 Too Many Requests</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 429 Too Many Requests</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/500.http
+++ b/errorfiles/500.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>500 Internal Server Error</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 500 Internal Server Error</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/502.http
+++ b/errorfiles/502.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>502 Bad Gateway</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 502 Bad Gateway</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/503.http
+++ b/errorfiles/503.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>503 Service Unavailable</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 503 Service Unavailable</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>

--- a/errorfiles/504.http
+++ b/errorfiles/504.http
@@ -4,9 +4,30 @@ Connection: close
 Content-Type: text/html
 
 <html>
+  <head>
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
+    <style>
+      body {
+        padding-top: 50px
+      }
+    </style>
+  </head>
   <body>
-    <h3>Docker Flow: Proxy</h3>
-    <h1>504 Gateway Timeout</h1>
-    No server is available to handle this request.
-  </body>
+  <div class="container">
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">Docker Flow Proxy: 504 Gateway Timeout</h3>
+        </div>
+      <div class="panel-body">
+        No server is available to handle this request.
+      </div>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
Nothing important, just made the error pages good looking ;)

![material-error-page](https://cloud.githubusercontent.com/assets/600106/22242038/22017778-e222-11e6-9ca6-3756599257d7.png)

If you do not want this in the project itself, i can also add a section to the docs, how to mount-bind a directory with custom error pages.