### PR TITLE
Add option http-keep-alive to defaults area

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -16,6 +16,7 @@ defaults
     option  http-server-close
     option  forwardfor
     option  redispatch
+    option  http-keep-alive
 
     errorfile 400 /errorfiles/400.http
     errorfile 403 /errorfiles/403.http


### PR DESCRIPTION
This PR adds `option http-keep-alive` to the defaults area of haproxy config.

Some services needs http-keep-alive to work like portainer. As far as I know websockets also use http-keep-alive.