### PR TITLE
First set of changes for SNI routing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /docker-flow-proxy
 *.bak
 /tmp
-/certs/test.pem
+/certs
 /*.log
 /*-token
 secrets*

--- a/actions/reconfigure.go
+++ b/actions/reconfigure.go
@@ -153,7 +153,7 @@ func (m *Reconfigure) reloadFromRegistry(addresses []string, instanceName, mode 
 		var data map[string]interface{}
 		json.Unmarshal(body, &data)
 		count = len(data)
-		for key, _ := range data {
+		for key := range data {
 			go m.getService(addresses, key, instanceName, c)
 		}
 	}
@@ -346,10 +346,14 @@ func (m *Reconfigure) getBackTemplateProtocol(protocol string, sr *proxy.Service
 	if strings.EqualFold(protocol, "https") {
 		prefix = "https-"
 	}
+	rmode := sr.ReqMode
+	if strings.EqualFold(sr.ReqMode, "sni") {
+		rmode = "tcp"
+	}
 	tmpl := fmt.Sprintf(`{{range .ServiceDest}}
 backend %s{{$.ServiceName}}-be{{.Port}}
-    mode {{$.ReqMode}}`,
-		prefix,
+    mode %s`,
+		prefix, rmode,
 	)
 	// TODO: Deprecated (dec. 2016).
 	if len(sr.TimeoutServer) > 0 {

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -26,7 +26,6 @@ defaults
 
 frontend dummy-fe
     bind *:80
-    bind *:443
     mode http
     option http-server-close
     acl url_dummy path_beg /dummy

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -42,8 +42,4 @@ defaults
     stats auth {{.StatsUser}}:{{.StatsPass}}
     stats uri /admin?stats
 {{.UserList}}
-frontend services
-    bind *:80
-    bind *:443{{.CertsString}}
-    mode http
-{{.ExtraFrontend}}{{.ContentFrontend}}{{.ContentFrontendTcp}}
+{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}{{.ContentFrontendSNI}}

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -42,4 +42,4 @@ defaults
     stats auth {{.StatsUser}}:{{.StatsPass}}
     stats uri /admin?stats
 {{.UserList}}
-{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}{{.ContentFrontendSNI}}
+{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}

--- a/integration_tests/integration_swarm_test.go
+++ b/integration_tests/integration_swarm_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"bytes"
 )
 
 // Setup

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
-	"testing"
 	"net/url"
 	"os/exec"
+	"strings"
+	"testing"
 )
 
 type IntegrationTestSuite struct {

--- a/proxy/test_configs/tmpl/haproxy.tmpl
+++ b/proxy/test_configs/tmpl/haproxy.tmpl
@@ -35,8 +35,4 @@ defaults
     stats auth {{.StatsUser}}:{{.StatsPass}}
     stats uri /admin?stats
 {{.UserList}}
-frontend services
-    bind *:80
-    bind *:443{{.CertsString}}
-    mode http
-{{.ExtraFrontend}}{{.ContentFrontend}}{{.ContentFrontendTcp}}
+{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}{{.ContentFrontendSNI}}

--- a/proxy/test_configs/tmpl/haproxy.tmpl
+++ b/proxy/test_configs/tmpl/haproxy.tmpl
@@ -35,4 +35,4 @@ defaults
     stats auth {{.StatsUser}}:{{.StatsPass}}
     stats uri /admin?stats
 {{.UserList}}
-{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}{{.ContentFrontendSNI}}
+{{.ContentFrontend}}{{.ExtraFrontend}}{{.ContentFrontendTcp}}

--- a/proxy/types.go
+++ b/proxy/types.go
@@ -3,61 +3,63 @@ package proxy
 type ServiceDest struct {
 	// The internal port of a service that should be reconfigured.
 	// The port is used only in the *swarm* mode.
-	Port 			string
+	Port string
 	// The URL path of the service.
-	ServicePath 	[]string
+	ServicePath []string
 	// The source (entry) port of a service.
 	// Useful only when specifying multiple destinations of a single service.
-	SrcPort        	int
-	SrcPortAcl     	string
-	SrcPortAclName 	string
+	SrcPort        int
+	SrcPortAcl     string
+	SrcPortAclName string
 }
 
 type Service struct {
 	// ACLs are ordered alphabetically by their names.
 	// If not specified, serviceName is used instead.
-	AclName 				string
+	AclName string
 	// The path to the Consul Template representing a snippet of the backend configuration.
 	// If set, proxy template will be loaded from the specified file.
-	ConsulTemplateFePath 	string
+	ConsulTemplateFePath string
 	// The path to the Consul Template representing a snippet of the frontend configuration.
 	// If specified, proxy template will be loaded from the specified file.
-	ConsulTemplateBePath 	string
+	ConsulTemplateBePath string
 	// Whether to distribute a request to all the instances of the proxy.
 	// Used only in the swarm mode.
-	Distribute 				bool
+	Distribute bool
 	// Whether to redirect all http requests to https
-	HttpsOnly       		bool
+	HttpsOnly bool
 	// The internal HTTPS port of a service that should be reconfigured.
 	// The port is used only in the swarm mode.
 	// If not specified, the `port` parameter will be used instead.
-	HttpsPort 				int
+	HttpsPort int
 	// The hostname where the service is running, for instance on a separate swarm.
 	// If specified, the proxy will dispatch requests to that domain.
-	OutboundHostname 		string
+	OutboundHostname string
 	// The ACL derivative. Defaults to path_beg.
 	// See https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.6-path for more info.
-	PathType 				string
-	// The request mode. The proxy should be able to work with any mode supported by HAProxy. However, actively supported and tested modes are *http* and *tcp*. Please open an GitHub issue if the mode you're using does not work as expected. The default value is *http*.
-	ReqMode 				string
+	PathType string
+	// The request mode. The proxy should be able to work with any mode supported by HAProxy. However, actively supported and tested modes are *http* and *tcp*.
+	// Please open an GitHub issue if the mode you're using does not work as expected. The default value is *http*.
+	// Adding support for *sni*. This implies TCP with an SNI-based routing.
+	ReqMode string
 	// Deprecated in favor of ReqPathReplace
-	ReqRepReplace 			string
+	ReqRepReplace string
 	// Deprecated in favor of ReqPathSearch
-	ReqRepSearch 			string
+	ReqRepSearch string
 	// A regular expression to apply the modification.
 	// If specified, `reqPathSearch` needs to be set as well.
-	ReqPathReplace 			string
+	ReqPathReplace string
 	// A regular expression to search the content to be replaced.
 	// If specified, `reqPathReplace` needs to be set as well.
-	ReqPathSearch 			string
+	ReqPathSearch string
 	// Content of the PEM-encoded certificate to be used by the proxy when serving traffic over SSL.
-	ServiceCert 			string
+	ServiceCert string
 	// The domain of the service.
 	// If set, the proxy will allow access only to requests coming to that domain.
-	ServiceDomain 			[]string
+	ServiceDomain []string
 	// The name of the service.
 	// It must match the name of the Swarm service or the one stored in Consul.
-	ServiceName 			string
+	ServiceName string
 	// Whether to skip adding proxy checks.
 	// This option is used only in the default mode.
 	SkipCheck bool
@@ -65,26 +67,26 @@ type Service struct {
 	// If specified, the backend template will be loaded from the specified file.
 	// If specified, `templateFePath` must be set as well.
 	// See the https://github.com/vfarcic/docker-flow-proxy#templates section for more info.
-	TemplateBePath 			string
+	TemplateBePath string
 	// The path to the template representing a snippet of the frontend configuration.
 	// If specified, the frontend template will be loaded from the specified file.
 	// If specified, `templateBePath` must be set as well.
 	// See the https://github.com/vfarcic/docker-flow-proxy#templates section for more info.
-	TemplateFePath 			string
+	TemplateFePath string
 	// The server timeout in seconds
-	TimeoutServer           string
+	TimeoutServer string
 	// The tunnel timeout in seconds
-	TimeoutTunnel           string
+	TimeoutTunnel string
 	// A comma-separated list of credentials(<user>:<pass>) for HTTP basic auth, which applies only to the service that will be reconfigured.
-	Users               	[]User
-	ServiceColor        	string
-	ServicePort         	string
-	AclCondition        	string
-	FullServiceName     	string
-	Host                	string
-	LookupRetry         	int
-	LookupRetryInterval 	int
-	ServiceDest         	[]ServiceDest
+	Users               []User
+	ServiceColor        string
+	ServicePort         string
+	AclCondition        string
+	FullServiceName     string
+	Host                string
+	LookupRetry         int
+	LookupRetryInterval int
+	ServiceDest         []ServiceDest
 }
 
 type Services []Service
@@ -94,7 +96,7 @@ func (slice Services) Len() int {
 }
 
 func (slice Services) Less(i, j int) bool {
-	return slice[i].AclName < slice[j].AclName;
+	return slice[i].AclName < slice[j].AclName
 }
 
 func (slice Services) Swap(i, j int) {

--- a/proxy/types.go
+++ b/proxy/types.go
@@ -40,7 +40,6 @@ type Service struct {
 	PathType string
 	// The request mode. The proxy should be able to work with any mode supported by HAProxy. However, actively supported and tested modes are *http* and *tcp*.
 	// Please open an GitHub issue if the mode you're using does not work as expected. The default value is *http*.
-	// Adding support for *sni*. This implies TCP with an SNI-based routing.
 	ReqMode string
 	// Deprecated in favor of ReqPathReplace
 	ReqRepReplace string

--- a/server.go
+++ b/server.go
@@ -109,7 +109,7 @@ func (m *Serve) isValidReconf(service *proxy.Service) (bool, string) {
 	hasSrcPort := service.ServiceDest[0].SrcPort > 0
 	hasPort := len(service.ServiceDest[0].Port) > 0
 	if strings.EqualFold(service.ReqMode, "http") {
-		if (!hasPath && len(service.ConsulTemplateFePath) == 0) {
+		if !hasPath && len(service.ConsulTemplateFePath) == 0 {
 			return false, "When using reqMode http, servicePath or (consulTemplateFePath and consulTemplateBePath) are mandatory"
 		}
 	} else if !hasSrcPort || !hasPort {
@@ -202,10 +202,10 @@ func (m *Serve) reconfigure(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	response := server.Response{
-		Mode:       	m.Mode,
-		Status:     	"OK",
-		ServiceName:    sr.ServiceName,
-		Service: 	    sr,
+		Mode:        m.Mode,
+		Status:      "OK",
+		ServiceName: sr.ServiceName,
+		Service:     sr,
 	}
 	ok, msg := m.isValidReconf(&sr)
 	if ok {

--- a/server/server.go
+++ b/server/server.go
@@ -21,10 +21,10 @@ func NewServer() *Serve {
 }
 
 type Response struct {
-	Mode                 string
-	Status               string
-	Message              string
-	ServiceName          string
+	Mode        string
+	Status      string
+	Message     string
+	ServiceName string
 	proxy.Service
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -415,7 +415,7 @@ func (s *ServerTestSuite) Test_ServeHTTP_SetsContentTypeToJSON_WhenUrlIsReconfig
 
 func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJSON_WhenUrlIsReconfigure() {
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
+		Status: "OK",
 		Service: proxy.Service{
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -425,7 +425,7 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJSON_WhenUrlIsReconfigure() {
 			ServiceDest:      []proxy.ServiceDest{s.sd},
 			ServiceName:      s.ServiceName,
 		},
-		ServiceName:      s.ServiceName,
+		ServiceName: s.ServiceName,
 	})
 
 	srv := Serve{}
@@ -437,22 +437,22 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJSON_WhenUrlIsReconfigure() {
 func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJSONWithAllPortsAndPaths() {
 	sd := []proxy.ServiceDest{
 		proxy.ServiceDest{
-			ServicePath:    []string{"/path/to/my-service"},
-			Port:    "1111",
-			SrcPort: 2222,
+			ServicePath: []string{"/path/to/my-service"},
+			Port:        "1111",
+			SrcPort:     2222,
 		},
 		proxy.ServiceDest{
-			ServicePath:    []string{"/path/to/my-service-1"},
-			Port:    "3333",
-			SrcPort: 4444,
+			ServicePath: []string{"/path/to/my-service-1"},
+			Port:        "3333",
+			SrcPort:     4444,
 		},
 		proxy.ServiceDest{
 			ServicePath: []string{"/path/to/my-service-2"},
-			Port: "4444",
+			Port:        "4444",
 		},
 	}
 	expected, _ := json.Marshal(server.Response{
-		Status:      "OK",
+		Status: "OK",
 		Service: proxy.Service{
 			ReqMode:     "http",
 			PathType:    s.PathType,
@@ -486,9 +486,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithPathType_WhenPresent() {
 	pathType := "path_reg"
 	req, _ := http.NewRequest("GET", s.ReconfigureUrl+"&pathType="+pathType, nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service: 		  proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ReqMode:          "http",
 			ServiceName:      s.ServiceName,
 			ServiceColor:     s.ServiceColor,
@@ -514,9 +514,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithReqRep_WhenPresent() {
 	)
 	req, _ := http.NewRequest("GET", url, nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ReqMode:          "http",
 			ServiceName:      s.ServiceName,
 			ServiceColor:     s.ServiceColor,
@@ -542,9 +542,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithReqPath_WhenPresent() {
 	)
 	req, _ := http.NewRequest("GET", url, nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ReqMode:          "http",
 			ServiceName:      s.ServiceName,
 			ServiceColor:     s.ServiceColor,
@@ -570,9 +570,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithMode_WhenPresent() {
 	)
 	req, _ := http.NewRequest("GET", url, nil)
 	expected, _ := json.Marshal(server.Response{
-		ServiceName:      s.ServiceName,
-		Status:           "OK",
-		Service:          proxy.Service{
+		ServiceName: s.ServiceName,
+		Status:      "OK",
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "tcp",
 			ServiceColor:     s.ServiceColor,
@@ -580,11 +580,11 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithMode_WhenPresent() {
 			OutboundHostname: s.OutboundHostname,
 			ReqPathSearch:    search,
 			ReqPathReplace:   replace,
-			ServiceDest:      []proxy.ServiceDest{
+			ServiceDest: []proxy.ServiceDest{
 				proxy.ServiceDest{
 					ServicePath: []string{"/path/to/my/service/api", "/path/to/my/other/service/api"},
-					SrcPort: 1234,
-					Port: "4321",
+					SrcPort:     1234,
+					Port:        "4321",
 				},
 			},
 		},
@@ -607,9 +607,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithTemplatePaths_WhenPresen
 	)
 	req, _ := http.NewRequest("GET", url, nil)
 	expected, _ := json.Marshal(server.Response{
-		ServiceName:      s.ServiceName,
-		Status:           "OK",
-		Service:          proxy.Service{
+		ServiceName: s.ServiceName,
+		Status:      "OK",
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -634,9 +634,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithUsers_WhenPresent() {
 	}
 	req, _ := http.NewRequest("GET", s.ReconfigureUrl+"&users=user1:pass1,user2:pass2", nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ReqMode:          "http",
 			ServiceName:      s.ServiceName,
 			ServiceColor:     s.ServiceColor,
@@ -666,13 +666,13 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithPorts_WhenPresent() {
 	req, _ := http.NewRequest("GET", address, nil)
 	sd := proxy.ServiceDest{
 		ServicePath: s.sd.ServicePath,
-		Port: port,
+		Port:        port,
 	}
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Mode:             mode,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Mode:        mode,
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -693,9 +693,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithPorts_WhenPresent() {
 func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithSkipCheck_WhenPresent() {
 	req, _ := http.NewRequest("GET", s.ReconfigureUrl+"&skipCheck=true", nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -716,9 +716,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonWithSkipCheck_WhenPresent() 
 func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonTimeoutServer_WhenPresent() {
 	req, _ := http.NewRequest("GET", s.ReconfigureUrl+"&timeoutServer=9999", nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -738,9 +738,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonTimeoutServer_WhenPresent() 
 func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJsonTimeoutTunnel_WhenPresent() {
 	req, _ := http.NewRequest("GET", s.ReconfigureUrl+"&timeoutTunnel=9999", nil)
 	expected, _ := json.Marshal(server.Response{
-		Status:           "OK",
-		ServiceName:      s.ServiceName,
-		Service:          proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ServiceName:      s.ServiceName,
 			ReqMode:          "http",
 			ServiceColor:     s.ServiceColor,
@@ -899,9 +899,9 @@ func (s *ServerTestSuite) Test_ServeHTTP_ReturnsJson_WhenConsulTemplatePathIsPre
 		ServicePath: []string{},
 	}
 	expected, _ := json.Marshal(server.Response{
-		Status:               "OK",
-		ServiceName:          s.ServiceName,
-		Service:              proxy.Service{
+		Status:      "OK",
+		ServiceName: s.ServiceName,
+		Service: proxy.Service{
 			ReqMode:              "http",
 			ServiceName:          s.ServiceName,
 			ConsulTemplateFePath: pathFe,


### PR DESCRIPTION
Removes the default frontend from template and add it back using code. Allows for multiple services to sit behind a multiple non-standard ports (!443, !80).