### PR TITLE
Removing Authentication header when authenticating

### DIFF
--- a/actions/reconfigure.go
+++ b/actions/reconfigure.go
@@ -393,11 +393,13 @@ backend %s{{$.ServiceName}}-be{{.Port}}
 	if len(sr.Users) > 0 {
 		tmpl += `
     acl {{$.ServiceName}}UsersAcl http_auth({{$.ServiceName}}Users)
-    http-request auth realm {{$.ServiceName}}Realm if !{{$.ServiceName}}UsersAcl`
+    http-request auth realm {{$.ServiceName}}Realm if !{{$.ServiceName}}UsersAcl
+    http-request del-header Authorization`
 	} else if len(os.Getenv("USERS")) > 0 {
 		tmpl += `
     acl defaultUsersAcl http_auth(defaultUsers)
-    http-request auth realm defaultRealm if !defaultUsersAcl`
+    http-request auth realm defaultRealm if !defaultUsersAcl
+    http-request del-header Authorization`
 	}
 	tmpl += "{{end}}"
 	return tmpl

--- a/actions/reconfigure_test.go
+++ b/actions/reconfigure_test.go
@@ -164,7 +164,8 @@ backend myService-be
     server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
     {{end}}
     acl defaultUsersAcl http_auth(defaultUsers)
-    http-request auth realm defaultRealm if !defaultUsersAcl`
+    http-request auth realm defaultRealm if !defaultUsersAcl
+    http-request del-header Authorization`
 
 	_, back, _ := s.reconfigure.GetTemplates(&s.reconfigure.Service)
 
@@ -188,7 +189,8 @@ backend myService-be
     server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
     {{end}}
     acl myServiceUsersAcl http_auth(myServiceUsers)
-    http-request auth realm myServiceRealm if !myServiceUsersAcl`
+    http-request auth realm myServiceRealm if !myServiceUsersAcl
+    http-request del-header Authorization`
 
 	_, back, _ := s.reconfigure.GetTemplates(&s.reconfigure.Service)
 
@@ -256,7 +258,8 @@ backend myService-be1234
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     server myService myService:1234
     acl defaultUsersAcl http_auth(defaultUsers)
-    http-request auth realm defaultRealm if !defaultUsersAcl`
+    http-request auth realm defaultRealm if !defaultUsersAcl
+    http-request del-header Authorization`
 
 	_, actual, _ := s.reconfigure.GetTemplates(&s.reconfigure.Service)
 
@@ -280,7 +283,8 @@ backend myService-be1234
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     server myService myService:1234
     acl myServiceUsersAcl http_auth(myServiceUsers)
-    http-request auth realm myServiceRealm if !myServiceUsersAcl`
+    http-request auth realm myServiceRealm if !myServiceUsersAcl
+    http-request del-header Authorization`
 
 	_, actual, _ := s.reconfigure.GetTemplates(&s.reconfigure.Service)
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -12,7 +12,7 @@ services:
     command: sh -c "go get -d -v -t && go test --cover ./... --run UnitTest && go build -v -o docker-flow-proxy"
 
   staging-dep:
-    image: vfarcic/docker-flow-proxy
+    image: ${DOCKER_HUB_USER}/docker-flow-proxy
     environment:
       - CONSUL_ADDRESS=consul:8500
       - PROXY_INSTANCE_NAME=proxy-test-instance
@@ -32,7 +32,7 @@ services:
       - app-1
 
   staging-service-proxy:
-    image: vfarcic/docker-flow-proxy
+    image: ${DOCKER_HUB_USER}/docker-flow-proxy
     environment:
       - PROXY_INSTANCE_NAME=proxy-service-test-instance
       - MODE=swarm


### PR DESCRIPTION
* swarm mode integration tests did not work when there was some containers running on host prior to test run and as I've got some running all the time I fixed it. I don't think it will break anything
* vfarcic/ in docker compose was fixed for docker-flow-proxy images - i think it tested this way your image not developed one
* I haven't added any additional tests as I feel existing ones cover the problem in 100%
* Question I have: can it be left as fixed behavior or should I add some sort of switch, if so where this switch should be, global or per service. I personally think it should be a fixed behavior but I won't argue if you think otherwise.