### PR TITLE
Force using Docker DNS resolver

### DIFF
--- a/actions/fetch_test.go
+++ b/actions/fetch_test.go
@@ -46,7 +46,7 @@ func (s *FetchTestSuite) SetupTest() {
 backend myService-be
     mode http
     {{range $i, $e := service "myService" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}`
 	s.ConsulAddress = s.Server.URL
 	s.fetch = Fetch{

--- a/actions/reconfigure.go
+++ b/actions/reconfigure.go
@@ -287,15 +287,15 @@ func (m *Reconfigure) getServerTemplate(protocol string) string {
 	if strings.EqualFold(m.Mode, "service") || strings.EqualFold(m.Mode, "swarm") {
 		if strings.EqualFold(protocol, "https") {
 			return `
-    server {{$.ServiceName}} {{$.Host}}:{{$.HttpsPort}}{{if eq $.SkipCheck false}} check{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}`
+    server {{$.ServiceName}} {{$.Host}}:{{$.HttpsPort}}{{if eq $.SkipCheck false}} check resolvers docker{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}`
 		} else {
 			return `
-    server {{$.ServiceName}} {{$.Host}}:{{.Port}}{{if eq $.SkipCheck false}} check{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}`
+    server {{$.ServiceName}} {{$.Host}}:{{.Port}}{{if eq $.SkipCheck false}} check resolvers docker{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}`
 		}
 	} else { // It's Consul
 		return `
     {{"{{"}}range $i, $e := service "{{$.FullServiceName}}" "any"{{"}}"}}
-    server {{"{{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}}"}}{{if eq $.SkipCheck false}} check{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}
+    server {{"{{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}}"}}{{if eq $.SkipCheck false}} check resolvers docker{{if eq $.SslVerifyNone true}} ssl verify none{{end}}{{end}}
     {{"{{end}}"}}`
 	}
 }

--- a/actions/reconfigure_test.go
+++ b/actions/reconfigure_test.go
@@ -49,7 +49,7 @@ func (s *ReconfigureTestSuite) SetupTest() {
 backend myService-be
     mode http
     {{range $i, $e := service "myService" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}`
 	s.ConsulAddress = s.Server.URL
 	s.reconfigure = Reconfigure{
@@ -115,7 +115,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpAuth_WhenUsersEnvIsPrese
 backend myService-be
     mode http
     {{range $i, $e := service "myService" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl
@@ -139,7 +139,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpAuth_WhenUsersIsPresent(
 backend myService-be
     mode http
     {{range $i, $e := service "myService" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}
     acl myServiceUsersAcl http_auth(myServiceUsers)
     http-request auth realm myServiceRealm if !myServiceUsersAcl
@@ -163,7 +163,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpAuth_WhenUsersIsPresentA
 backend myService-be
     mode http
     {{range $i, $e := service "myService" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}
     acl myServiceUsersAcl http_auth(myServiceUsers)
     http-request auth realm myServiceRealm if !myServiceUsersAcl
@@ -182,7 +182,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_ReturnsFormattedContent_WhenMode
 		expected := `
 backend myService-be1234
     mode http
-    server myService myService:1234 check`
+    server myService myService:1234 check resolvers docker`
 
 		_, actual, _ := s.reconfigure.GetTemplates()
 
@@ -216,7 +216,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddSllVerifyNone_WhenSslVerifyNo
 		expected := `
 backend myService-be1234
     mode http
-    server myService myService:1234 check ssl verify none`
+    server myService myService:1234 check resolvers docker ssl verify none`
 
 		_, actual, _ := s.reconfigure.GetTemplates()
 
@@ -231,7 +231,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_ReturnsFormattedContent_WhenReqM
 	expected := `
 backend myService-be1234
     mode tcp
-    server myService myService:1234 check`
+    server myService myService:1234 check resolvers docker`
 
 	_, actual, _ := s.reconfigure.GetTemplates()
 
@@ -247,7 +247,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpAuth_WhenModeIsSwarmAndU
 	expected := `
 backend myService-be1234
     mode http
-    server myService myService:1234 check
+    server myService myService:1234 check resolvers docker
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl
     http-request del-header Authorization`
@@ -271,7 +271,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpAuth_WhenModeIsSwarmAndU
 
 backend myService-be1234
     mode http
-    server myService myService:1234 check
+    server myService myService:1234 check resolvers docker
     acl myServiceUsersAcl http_auth(myServiceUsers)
     http-request auth realm myServiceRealm if !myServiceUsersAcl
     http-request del-header Authorization`
@@ -285,11 +285,11 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsHttpsPort_WhenPresent() {
 	expectedBack := `
 backend myService-be1234
     mode http
-    server myService myService:1234 check
+    server myService myService:1234 check resolvers docker
 
 backend https-myService-be1234
     mode http
-    server myService myService:4321 check`
+    server myService myService:4321 check resolvers docker`
 	s.reconfigure.ServiceDest[0].Port = "1234"
 	s.reconfigure.Mode = "service"
 	s.reconfigure.HttpsPort = 4321
@@ -304,7 +304,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsConnectionMode_WhenPresent()
 backend myService-be1234
     mode http
     option my-connection-mode
-    server myService myService:1234 check`
+    server myService myService:1234 check resolvers docker`
 	s.reconfigure.ServiceDest[0].Port = "1234"
 	s.reconfigure.Mode = "service"
 	s.reconfigure.ConnectionMode = "my-connection-mode"
@@ -319,7 +319,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsTimeoutServer_WhenPresent() 
 backend myService-be1234
     mode http
     timeout server 9999s
-    server myService myService:1234 check`
+    server myService myService:1234 check resolvers docker`
 	s.reconfigure.ServiceDest[0].Port = "1234"
 	s.reconfigure.TimeoutServer = "9999"
 	s.reconfigure.Mode = "service"
@@ -334,7 +334,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsTimeoutTunnel_WhenPresent() 
 backend myService-be1234
     mode http
     timeout tunnel 9999s
-    server myService myService:1234 check`
+    server myService myService:1234 check resolvers docker`
 	s.reconfigure.ServiceDest[0].Port = "1234"
 	s.reconfigure.TimeoutTunnel = "9999"
 	s.reconfigure.Mode = "service"
@@ -353,13 +353,13 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsMultipleDestinations() {
 	expectedBack := `
 backend myService-be1111
     mode http
-    server myService myService:1111 check
+    server myService myService:1111 check resolvers docker
 backend myService-be3333
     mode tcp
-    server myService myService:3333 check
+    server myService myService:3333 check resolvers docker
 backend myService-be5555
     mode http
-    server myService myService:5555 check`
+    server myService myService:5555 check resolvers docker`
 	s.reconfigure.ServiceDest = sd
 	s.reconfigure.Mode = "service"
 	actualFront, actualBack, _ := s.reconfigure.GetTemplates()
@@ -377,7 +377,7 @@ backend myService-be
     mode http
     reqrep %s     %s
     {{range $i, $e := service "%s" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}`,
 		s.reconfigure.ReqRepSearch,
 		s.reconfigure.ReqRepReplace,
@@ -397,7 +397,7 @@ backend myService-be
     mode http
     http-request set-path %%[path,regsub(%s,%s)]
     {{range $i, $e := service "%s" "any"}}
-    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+    server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
     {{end}}`,
 		s.reconfigure.ReqPathSearch,
 		s.reconfigure.ReqPathReplace,
@@ -419,7 +419,7 @@ func (s ReconfigureTestSuite) Test_GetTemplates_AddsColor() {
 }
 
 func (s ReconfigureTestSuite) Test_GetTemplates_DoesNotSetCheckWhenSkipCheckIsTrue() {
-	s.ConsulTemplateBe = strings.Replace(s.ConsulTemplateBe, " check", "", -1)
+	s.ConsulTemplateBe = strings.Replace(s.ConsulTemplateBe, " check resolvers docker", "", -1)
 	s.reconfigure.SkipCheck = true
 	_, actual, _ := s.reconfigure.GetTemplates()
 
@@ -547,7 +547,7 @@ func (s ReconfigureTestSuite) Test_Execute_WritesBeTemplate_WhenModeIsService() 
 		`
 backend %s-be%s
     mode http
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -576,7 +576,7 @@ func (s ReconfigureTestSuite) Test_Execute_WritesBeTemplate_WhenModeIsSwarm() {
 		`
 backend %s-be%s
     mode http
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -607,7 +607,7 @@ func (s ReconfigureTestSuite) Test_Execute_AddsXForwardedProto_WhenTrue() {
 backend %s-be%s
     mode http
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -639,7 +639,7 @@ backend %s-be%s
     mode http
     http-request add-header header-1
     http-request add-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -671,7 +671,7 @@ backend %s-be%s
     mode http
     http-response add-header header-1
     http-response add-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -703,7 +703,7 @@ backend %s-be%s
     mode http
     http-request set-header header-1
     http-request set-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -735,7 +735,7 @@ backend %s-be%s
     mode http
     http-response set-header header-1
     http-response set-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -767,7 +767,7 @@ backend %s-be%s
     mode http
     http-request del-header header-1
     http-request del-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,
@@ -799,7 +799,7 @@ backend %s-be%s
     mode http
     http-response del-header header-1
     http-response del-header header-2
-    server %s %s:%s check`,
+    server %s %s:%s check resolvers docker`,
 		s.ServiceName,
 		s.reconfigure.ServiceDest[0].Port,
 		s.ServiceName,

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -9,6 +9,9 @@ global
     ssl-default-server-options {{.SslBindOptions}}
     ssl-default-server-ciphers {{.SslBindCiphers}}
 
+resolvers docker
+    nameserver dns 127.0.0.11:53
+
 defaults
     mode    http
     balance roundrobin

--- a/proxy/ha_proxy.go
+++ b/proxy/ha_proxy.go
@@ -176,7 +176,7 @@ func (m HaProxy) getConfigs() (string, error) {
     use_backend dummy-be if url_dummy
 
 backend dummy-be
-    server dummy 1.1.1.1:1111 check`)
+    server dummy 1.1.1.1:1111 check resolvers docker`)
 	}
 	tmpl, _ := template.New("contentTemplate").Parse(
 		strings.Join(contentArr, "\n\n"),

--- a/proxy/ha_proxy_test.go
+++ b/proxy/ha_proxy_test.go
@@ -1450,7 +1450,7 @@ func (s HaProxyTestSuite) Test_CreateConfigFromTemplates_WritesMockDataIfConfigs
     use_backend dummy-be if url_dummy
 
 backend dummy-be
-    server dummy 1.1.1.1:1111 check`,
+    server dummy 1.1.1.1:1111 check resolvers docker`,
 	)
 
 	writeFile = func(filename string, data []byte, perm os.FileMode) error {

--- a/proxy/test_configs/tmpl/go-demo-be.tmpl
+++ b/proxy/test_configs/tmpl/go-demo-be.tmpl
@@ -1,4 +1,4 @@
 backend go-demo-be
 	{{ range $i, $e := service "go-demo" "any" }}
-	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
 	{{end}}

--- a/proxy/test_configs/tmpl/my-service-be.tmpl
+++ b/proxy/test_configs/tmpl/my-service-be.tmpl
@@ -1,4 +1,4 @@
 backend test-service-be
 	{{ range $i, $e := service "test-service" "any" }}
-	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
 	{{end}}

--- a/test_configs/reload-error.cfg
+++ b/test_configs/reload-error.cfg
@@ -57,7 +57,7 @@ frontend services
 backend test-other-service-be
     mode http
 
-    server 7d2f499d261b_0_32770 192.168.99.105:32770 check
+    server 7d2f499d261b_0_32770 192.168.99.105:32770 check resolvers docker
 
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl
@@ -65,11 +65,11 @@ backend test-other-service-be
 backend test-service-be
     mode http
 
-    server 7d2f499d261b_0_32768 192.168.99.105:32768 check
+    server 7d2f499d261b_0_32768 192.168.99.105:32768 check resolvers docker
 
-    server 7d2f499d261b_1_32771 192.168.99.105:32771 check
+    server 7d2f499d261b_1_32771 192.168.99.105:32771 check resolvers docker
 
-    server 7d2f499d261b_2_32769 192.168.99.105:32769 check
+    server 7d2f499d261b_2_32769 192.168.99.105:32769 check resolvers docker
 
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl

--- a/test_configs/reload.cfg
+++ b/test_configs/reload.cfg
@@ -57,7 +57,7 @@ frontend services
 backend test-other-service-be
     mode http
 
-    server 7d2f499d261b_0_32770 192.168.99.105:32770 check
+    server 7d2f499d261b_0_32770 192.168.99.105:32770 check resolvers docker
 
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl
@@ -65,11 +65,11 @@ backend test-other-service-be
 backend test-service-be
     mode http
 
-    server 7d2f499d261b_0_32768 192.168.99.105:32768 check
+    server 7d2f499d261b_0_32768 192.168.99.105:32768 check resolvers docker
 
-    server 7d2f499d261b_1_32771 192.168.99.105:32771 check
+    server 7d2f499d261b_1_32771 192.168.99.105:32771 check resolvers docker
 
-    server 7d2f499d261b_2_32769 192.168.99.105:32769 check
+    server 7d2f499d261b_2_32769 192.168.99.105:32769 check resolvers docker
 
     acl defaultUsersAcl http_auth(defaultUsers)
     http-request auth realm defaultRealm if !defaultUsersAcl

--- a/test_configs/tmpl/my-service-be.tmpl
+++ b/test_configs/tmpl/my-service-be.tmpl
@@ -1,4 +1,4 @@
 backend test-service-be
 	{{ range $i, $e := service "test-service" "any" }}
-	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check
+	server {{$e.Node}}_{{$i}}_{{$e.Port}} {{$e.Address}}:{{$e.Port}} check resolvers docker
 	{{end}}


### PR DESCRIPTION
HAProxy will update DNS names for services.

Now proxy can be started first before any services are running yet.

This allows to make service UP when starting with `init-addr none` so IP of service will be resolver later when service will be UP. Because of behaviour above you can have service with 0 replicas in Docker Swarm now.

This change was tested only with changing `/cfg/haproxy.cfg` internally inside container and reloading HAProxy inside container for testing purposes. Please test it with other usecases like Non-Swarm DFP mode, but looking through Google it looks like `127.0.0.11` is Docker DNS like… always?