### PR TITLE
Updated tutorial docs with regards to SERVICE_NAME

### DIFF
--- a/docs/swarm-mode-auto.md
+++ b/docs/swarm-mode-auto.md
@@ -84,6 +84,9 @@ docker service create --name proxy \
 
 We opened the ports *80* and *443*. External requests will be routed through them towards destination services. The proxy is attached to the *proxy* network and has the mode set to *swarm*. The proxy must belong to the same network as the listener. They will exchange information whenever a service is created or removed.
 
+!!! info
+	If you call the service something other than *proxy*, like in the example above, you have to pass the environment variable `SERVICE_NAME` on creation. The value of `SERVICE_NAME` has to be the same as the name of the service.
+
 Let's deploy the demo service. It consists of two containers; *mongo* is the database and *vfarcic/go-demo* is the actual service that uses it. They will communicate with each other through the *go-demo* network. Since we want to expose only *vfarcic/go-demo* to the "outside" world and keep the database "private", only the *vfarcic/go-demo* container will attach itself to the *proxy* network.
 
 ```bash

--- a/docs/swarm-mode-auto.md
+++ b/docs/swarm-mode-auto.md
@@ -85,7 +85,7 @@ docker service create --name proxy \
 We opened the ports *80* and *443*. External requests will be routed through them towards destination services. The proxy is attached to the *proxy* network and has the mode set to *swarm*. The proxy must belong to the same network as the listener. They will exchange information whenever a service is created or removed.
 
 !!! info
-	If you call the service something other than *proxy*, like in the example above, you have to pass the environment variable `SERVICE_NAME` on creation. The value of `SERVICE_NAME` has to be the same as the name of the service.
+	If you name the service something other than *proxy*, you have to pass the environment variable `SERVICE_NAME` on creation. The value of `SERVICE_NAME` has to be the same as the name of the service.
 
 Let's deploy the demo service. It consists of two containers; *mongo* is the database and *vfarcic/go-demo* is the actual service that uses it. They will communicate with each other through the *go-demo* network. Since we want to expose only *vfarcic/go-demo* to the "outside" world and keep the database "private", only the *vfarcic/go-demo* container will attach itself to the *proxy* network.
 


### PR DESCRIPTION
Added clarification in the tutorial for automatic swarm mode, with regards to SERVICE_NAME if the name of the proxy differs from the example.

I was unsure if it also needed to be specified in swarm-mode-manual and swarm-mode-stack, as those seemed to presume that the reader had read the swarm-mode-auto tutorial.