### PR TITLE
Fixes Reloading of proxy seems to result in HAProxy zombies over time #245

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ EXPOSE 443
 EXPOSE 8080
 
 RUN apk --no-cache add tini
+ENTRYPOINT ["/sbin/tini","--"]
 CMD ["docker-flow-proxy", "server"]
 
 COPY errorfiles /errorfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ EXPOSE 80
 EXPOSE 443
 EXPOSE 8080
 
+RUN apk --no-cache add tini
 CMD ["docker-flow-proxy", "server"]
 
 COPY errorfiles /errorfiles


### PR DESCRIPTION
This adds the **tini** package from the Alpine repositories and sets **/sbin/tini** as entrypoint.

Having tini as entrypoint allows it to forward signals and reap children for docker-flow-proxy, and otherwise be a transparent replacement for HAproxy's builtin **/docker-entrypoint.sh.**
This solves the problem where I get thousands of <defunct> haproxy-processes on my cluster nodes.

Since docker-compose file version 3.x does not include the "init" key we cannot leverage Dockers builtin support for tini, but this may change in the future. If so, this PR is not needed any more.