### PR TITLE
Switched over to using a buffer for stdout,stderr on execute

### DIFF
--- a/proxy/util.go
+++ b/proxy/util.go
@@ -18,7 +18,7 @@ import (
 
 var cmdRunHa = func(args []string) error {
         var stdoutBuf, stderrBuf bytes.Buffer
-        cmd := out, err := exec.Command("haproxy", args...)
+        cmd := exec.Command("haproxy", args...)
 
         stdoutIn, _ := cmd.StdoutPipe()
         stderrIn, _ := cmd.StderrPipe()


### PR DESCRIPTION
Instead of using Combinedout, switched to using a pipe for stdout and stderr. It seems like running a command on HAProxy doesn't capture the entire stdout and stderr. This will ensure we get everything and see what is actually going if there is an error.