### PR TITLE
add inverse checks for x-forwarded-proto

### DIFF
--- a/proxy/ha_proxy_test.go
+++ b/proxy/ha_proxy_test.go
@@ -1468,6 +1468,8 @@ func (s HaProxyTestSuite) Test_CreateConfigFromTemplates_ForwardsToHttps_WhenRed
     acl domain_my-service1111_0 hdr_beg(host) -i my-domain.com
     acl is_my-service_http hdr(X-Forwarded-Proto) http
     http-request redirect scheme https if is_my-service_http url_my-service1111_0 domain_my-service1111_0
+    acl is_my-service_https hdr(X-Forwarded-Proto) https
+    http-request redirect scheme https if ! is_my-service_https url_my-service1111_0 domain_my-service1111_0
     use_backend my-service-be1111_0 if url_my-service1111_0 domain_my-service1111_0%s`,
 		tmpl,
 		s.ServicesContent,

--- a/proxy/template.go
+++ b/proxy/template.go
@@ -50,6 +50,8 @@ func getFrontTemplate(s Service) string {
             {{- if ne .Port ""}}
     acl is_{{$.AclName}}_http hdr(X-Forwarded-Proto) http
     http-request redirect scheme https if is_{{$.AclName}}_http url_{{$.AclName}}{{.Port}}_{{.Index}}{{if .ServiceDomain}} domain_{{$.AclName}}{{.Port}}_{{.Index}}{{end}}{{.SrcPortAclName}}
+    acl is_{{$.AclName}}_https hdr(X-Forwarded-Proto) https
+    http-request redirect scheme https if ! is_{{$.AclName}}_https url_{{$.AclName}}{{.Port}}_{{.Index}}{{if .ServiceDomain}} domain_{{$.AclName}}{{.Port}}_{{.Index}}{{end}}{{.SrcPortAclName}}
             {{- end}}
         {{- end}}
     {{- end}}


### PR DESCRIPTION
when using docker-for-aws, you can currently only configure the ELB to use HTTPS or TCP listeners. Not HTTP listeners. That means that x-forwarded-proto headers are only injected for HTTPS, not HTTP. This PR tries to remediate this issue by checking if the x-forwarded-proto is _not_ HTTPS, but the `redirectWhenHttpProto` label is set.