### PR TITLE
removing material design theme from errorfiles fixes #388

### DIFF
--- a/errorfiles/400.http
+++ b/errorfiles/400.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/403.http
+++ b/errorfiles/403.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/405.http
+++ b/errorfiles/405.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/408.http
+++ b/errorfiles/408.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/429.http
+++ b/errorfiles/429.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/500.http
+++ b/errorfiles/500.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/502.http
+++ b/errorfiles/502.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/503.http
+++ b/errorfiles/503.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px

--- a/errorfiles/504.http
+++ b/errorfiles/504.http
@@ -5,14 +5,8 @@ Content-Type: text/html
 
 <html>
   <head>
-    <!-- Material Design fonts -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700">
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- Bootstrap -->
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <!-- Bootstrap Material Design -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/bootstrap-material-design.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/FezVrasta/bootstrap-material-design/master/dist/css/ripples.min.css">
     <style>
       body {
         padding-top: 50px


### PR DESCRIPTION
A slightly opinionated bug fix here:

Issue #388 shows that haproxy custom error pages had header URL's for css that was no longer working on the web.

Researching the new URL's for those resources showed that the broken repo now focus was on a new beta version of the theme and bootstrap.

So I stepped back a minute and thought "why are we adding two fonts and multiple css files to error pages simply to customize the look, when the standard bootstrap css would still look good and reduce the need for all the extra theme files."

**So this PR provides:**

- Removes need on 3rd party theme on top of bootstrap
- Still provides good looking errors via a single header css of official bootstrap CDN
- Fixes #388 

**Errors look like this**

<img width="726" alt="screen shot 2017-11-28 at 4 35 35 pm" src="https://user-images.githubusercontent.com/792287/33345615-e8c9b4ee-d45a-11e7-924c-b7dc57f7206f.png">

Note that flow-proxy users are still able to provide their own custom error messages by adding them via a new custom image based on docker-flow-proxy or overwriting them at runtime with a volume.