### PR TITLE
Haproxy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ EXPOSE 443
 EXPOSE 8080
 
 RUN apk --no-cache add tini
-ENTRYPOINT ["/sbin/tini","--"]
+ENTRYPOINT ["/sbin/tini", "-g", "--"]
 CMD ["docker-flow-proxy", "server"]
 HEALTHCHECK --interval=5s --start-period=3s --timeout=5s CMD check.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go test --cover ./... --run UnitTest
 RUN go build -v -o docker-flow-proxy
 
 
-FROM haproxy:1.8-alpine
+FROM haproxy:1.8.3-alpine
 MAINTAINER 	Viktor Farcic <viktor@farcic.com>
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
`haproxy:1.8-alpine` now points to `haproxy:1.8.4-alpine`. When DFP is built with `1.8.4`, I am not able to run through the tutorial: http://proxy.dockerflow.com/swarm-mode-manual/. Pinning the version to `1.8.3` fixes the issue. This may have caused recent integration tests to fail.

I also added the `-g` option to `tini` to attempt to fix the stalled container issue.